### PR TITLE
cabal: Also increase transformers version in the tests

### DIFF
--- a/pipes-extras.cabal
+++ b/pipes-extras.cabal
@@ -36,10 +36,10 @@ test-suite tests
     Default-Language: Haskell2010
 
     Build-Depends:
-        base                       >= 4       && < 5   ,
-        pipes-extras                                   ,
-        pipes                      >= 4.0     && < 4.4 ,
+        base,
+        pipes-extras,
+        pipes,
         test-framework             >= 0.4     && < 1   ,
         test-framework-hunit       >= 0.3     && < 1   ,
         HUnit                      >= 1.2     && < 1.7 ,
-        transformers               >= 0.2.0.0 && < 0.7
+        transformers

--- a/pipes-extras.cabal
+++ b/pipes-extras.cabal
@@ -42,4 +42,4 @@ test-suite tests
         test-framework             >= 0.4     && < 1   ,
         test-framework-hunit       >= 0.3     && < 1   ,
         HUnit                      >= 1.2     && < 1.7 ,
-        transformers               >= 0.2.0.0 && < 0.6
+        transformers               >= 0.2.0.0 && < 0.7


### PR DESCRIPTION
The library component has transformers <0.7 but the test-suite component had transformers <0.6.

I was wondering, would it be better to remove version bounds from every `build-depends` in the `test-suite` and `executable` components where:
1. the `library` component also has that library as a `build-depends`, and
2. the bounds should not be less than what is given in the `library` component, and
3. the `test-suite` or `executable` has a dependency on the `library` component.


Thanks
